### PR TITLE
Add travis config

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,1 @@
+language: nix


### PR DESCRIPTION
This minimal travis config just configures language to nix which means
travis will simply run `nix-build`.