### PR TITLE
Refactoring

### DIFF
--- a/src/hydra.rs
+++ b/src/hydra.rs
@@ -1,0 +1,62 @@
+use serde::{Deserialize, Serialize};
+pub use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Input {
+    pub value: Option<String>,
+    #[serde(rename = "type")]
+    pub input_type: String,
+    pub revision: Option<String>,
+    pub uri: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Eval {
+    pub jobsetevalinputs: HashMap<String, Input>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Jobset {
+    pub nixexprpath: String,
+    pub nixexprinput: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Path {
+    pub path: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Build {
+    pub id: i64,
+    pub project: String,
+    pub drvpath: String,
+    pub job: String,
+    pub jobset: String,
+    pub buildoutputs: HashMap<String, Path>,
+    pub stoptime: i64,
+    pub jobsetevals: Vec<i64>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Search {
+    pub builds: Vec<Build>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Reproduce {
+    pub build: Build,
+    pub eval: Eval,
+    pub jobset: Jobset,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct JobsetOverview {
+    pub nrscheduled: i64,
+    pub nrtotal: i64,
+    pub nrsucceeded: i64,
+    pub project: String,
+    pub name: String,
+    pub nrfailed: i64,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 extern crate chrono;
 extern crate serde_derive;
+#[macro_use]
+extern crate log;
 
 pub mod hydra;
 pub mod pretty;
+pub mod query;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 extern crate chrono;
+extern crate clap;
+extern crate reqwest;
 extern crate serde_derive;
+
 #[macro_use]
 extern crate log;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ extern crate serde_derive;
 extern crate log;
 
 pub mod hydra;
+pub mod ops;
 pub mod pretty;
 pub mod query;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+extern crate serde_derive;
+
+pub mod hydra;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate chrono;
 extern crate serde_derive;
 
 pub mod hydra;
+pub mod pretty;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ extern crate serde_derive;
 #[macro_use]
 extern crate log;
 
+#[macro_use]
+extern crate prettytable;
+
 pub mod hydra;
 pub mod ops;
 pub mod pretty;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,16 +61,16 @@ fn main() -> Result<(), Error> {
             args.value_of("limit").unwrap().parse().unwrap(),
         ),
 
-        ("reproducible", Some(args)) => reproduce::run(
+        ("reproduce", Some(args)) => reproduce::run(
             host,
             args.value_of("QUERY").unwrap(),
-            matches.is_present("json"),
+            args.is_present("json"),
         ),
 
         ("project", Some(args)) => project::run(
             host,
             args.value_of("PROJECT").unwrap(),
-            matches.is_present("json"),
+            args.is_present("json"),
         ),
 
         _ => Ok(()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,11 @@ fn main() -> Result<(), Error> {
             args.value_of("limit").unwrap().parse().unwrap(),
         ),
 
-        ("reproducible", Some(args)) => reproduce::run(host, args.value_of("QUERY").unwrap()),
+        ("reproducible", Some(args)) => reproduce::run(
+            host,
+            args.value_of("QUERY").unwrap(),
+            matches.is_present("json"),
+        ),
 
         ("project", Some(args)) => project::run(
             host,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,49 +4,15 @@ use hydra_cli::hydra::Reproduce;
 use hydra_cli::pretty::{build_pretty_print, evaluation_pretty_print};
 use hydra_cli::query::{eval, jobset, jobsetOverview, search};
 
-extern crate clap;
-extern crate reqwest;
-
 use clap::{App, Arg, SubCommand};
 use reqwest::Error;
+
 #[macro_use]
 extern crate log;
 
 #[macro_use]
 extern crate prettytable;
 use prettytable::format;
-use serde_json::Value;
-
-#[cfg(test)]
-use std::fs::File;
-#[cfg(test)]
-use std::io::prelude::*;
-
-#[test]
-// This is useful for developping purpose (this is not a test yet).
-fn builds() -> Result<(), std::io::Error> {
-    let mut file = File::open("data/search-build.json")?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)?;
-    let s: Search = serde_json::from_str(&contents)?;
-
-    for b in s.builds {
-        build_pretty_print(&b);
-        println!();
-    }
-    Ok(())
-}
-
-#[test]
-// This is useful for developping purpose (this is not a test yet).
-fn test_eval() -> Result<(), std::io::Error> {
-    let mut file = File::open("data/eval-1525352.json")?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)?;
-    let e: Eval = serde_json::from_str(&contents)?;
-    evaluation_pretty_print(&e);
-    Ok(())
-}
 
 fn main() -> Result<(), Error> {
     let matches = App::new("hydra-cli")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
+extern crate hydra_cli;
+
+use hydra_cli::hydra::{Build, Eval, Jobset, JobsetOverview, Reproduce, Search};
+
 extern crate clap;
 extern crate reqwest;
-extern crate serde_derive;
+
 use clap::{App, Arg, SubCommand};
 use reqwest::Error;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::collections::HashMap;
 extern crate chrono;
 use chrono::NaiveDateTime;
 #[macro_use]
@@ -15,7 +16,7 @@ use serde::de::DeserializeOwned;
 #[macro_use]
 extern crate prettytable;
 use prettytable::format;
-use prettytable::{Cell, Row, Table};
+pub use serde_json::Value;
 
 #[cfg(test)]
 use std::fs::File;
@@ -46,65 +47,6 @@ fn test_eval() -> Result<(), std::io::Error> {
     let e: Eval = serde_json::from_str(&contents)?;
     evaluation_pretty_print(&e);
     Ok(())
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Input {
-    value: Option<String>,
-    #[serde(rename = "type")]
-    input_type: String,
-    revision: Option<String>,
-    uri: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Eval {
-    jobsetevalinputs: HashMap<String, Input>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Jobset {
-    nixexprpath: String,
-    nixexprinput: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct Path {
-    path: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct Build {
-    id: i64,
-    project: String,
-    drvpath: String,
-    job: String,
-    jobset: String,
-    buildoutputs: HashMap<String, Path>,
-    stoptime: i64,
-    jobsetevals: Vec<i64>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Search {
-    builds: Vec<Build>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Reproduce {
-    build: Build,
-    eval: Eval,
-    jobset: Jobset,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct JobsetOverview {
-    nrscheduled: i64,
-    nrtotal: i64,
-    nrsucceeded: i64,
-    project: String,
-    name: String,
-    nrfailed: i64,
 }
 
 fn build_pretty_print(b: &Build) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,7 @@
 extern crate hydra_cli;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate prettytable;
 
 use clap::{App, Arg, SubCommand};
-use hydra_cli::hydra::Reproduce;
 use hydra_cli::ops::{project, reproduce, search};
-use hydra_cli::pretty::{build_pretty_print, evaluation_pretty_print};
-use hydra_cli::query::{eval, jobset, jobsetOverview, search};
-use prettytable::format;
 use reqwest::Error;
 
 fn main() -> Result<(), Error> {
@@ -71,7 +63,11 @@ fn main() -> Result<(), Error> {
 
         ("reproducible", Some(args)) => reproduce::run(host, args.value_of("QUERY").unwrap()),
 
-        ("project", Some(args)) => project::run(host, args.value_of("PROJECT").unwrap()),
+        ("project", Some(args)) => project::run(
+            host,
+            args.value_of("PROJECT").unwrap(),
+            matches.is_present("json"),
+        ),
 
         _ => Ok(()),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use clap::{App, Arg, SubCommand};
 use reqwest::Error;
 #[macro_use]
 extern crate log;
-use serde::de::DeserializeOwned;
 
 #[macro_use]
 extern crate prettytable;
@@ -33,7 +32,7 @@ fn builds() -> Result<(), std::io::Error> {
 
     for b in s.builds {
         build_pretty_print(&b);
-        println!("");
+        println!();
     }
     Ok(())
 }
@@ -118,7 +117,7 @@ fn main() -> Result<(), Error> {
             matches.value_of("QUERY").unwrap().to_string(),
             1,
         )?;
-        if search.builds.len() == 0 {
+        if search.builds.is_empty() {
             println!("No builds found. Exiting.");
             return Ok(());
         } else if search.builds.len() > 1 {
@@ -135,8 +134,8 @@ fn main() -> Result<(), Error> {
         )?;
         let reproduce = Reproduce {
             build: search.builds.swap_remove(0),
-            eval: eval,
-            jobset: jobset,
+            eval,
+            jobset,
         };
 
         if matches.is_present("json") {
@@ -170,7 +169,7 @@ fn main() -> Result<(), Error> {
             for j in project {
                 let mut nrfailed = j.nrfailed.to_string();
                 let mut nrscheduled = j.nrscheduled.to_string();
-                let mut name = j.name;
+                let name = j.name;
                 if j.nrfailed == 0 {
                     nrfailed = "".to_string();
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 extern crate hydra_cli;
 
-use hydra_cli::hydra::{Eval, Jobset, JobsetOverview, Reproduce, Search};
+use hydra_cli::hydra::Reproduce;
 use hydra_cli::pretty::{build_pretty_print, evaluation_pretty_print};
+use hydra_cli::query::{eval, jobset, jobsetOverview, search};
 
 extern crate clap;
 extern crate reqwest;
@@ -15,7 +16,7 @@ use serde::de::DeserializeOwned;
 #[macro_use]
 extern crate prettytable;
 use prettytable::format;
-pub use serde_json::Value;
+use serde_json::Value;
 
 #[cfg(test)]
 use std::fs::File;
@@ -46,57 +47,6 @@ fn test_eval() -> Result<(), std::io::Error> {
     let e: Eval = serde_json::from_str(&contents)?;
     evaluation_pretty_print(&e);
     Ok(())
-}
-
-fn query<T: DeserializeOwned>(request_url: String) -> Result<T, Error> {
-    debug!("Request url: {}", request_url);
-    let client = reqwest::Client::new();
-    let mut res = client
-        .get(&request_url)
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .send()?;
-
-    let v: Value = res.json()?;
-    let res = serde_json::from_value(v).unwrap();
-    Ok(res)
-}
-
-fn eval(host: String, number: i64) -> Result<Eval, Error> {
-    let request_url = format!("{host}/eval/{number}", host = host, number = number);
-    let res: Eval = query(request_url)?;
-    Ok(res)
-}
-
-fn jobsetOverview(host: String, project: String) -> Result<Vec<JobsetOverview>, Error> {
-    let request_url = format!(
-        "{host}/api/jobsets?project={project}",
-        host = host,
-        project = project
-    );
-    let res: Vec<JobsetOverview> = query(request_url)?;
-    Ok(res)
-}
-
-fn jobset(host: String, project: String, jobset: String) -> Result<Jobset, Error> {
-    let request_url = format!(
-        "{host}/jobset/{project}/{jobset}",
-        host = host,
-        project = project,
-        jobset = jobset
-    );
-    let res: Jobset = query(request_url)?;
-    Ok(res)
-}
-
-fn search(host: String, queri: String, limit: usize) -> Result<Search, Error> {
-    let request_url = format!("{host}/search?query={query}", host = host, query = queri);
-    let mut search: Search = query(request_url)?;
-    // TODO: implement limit in Hydra API
-    if search.builds.len() > limit {
-        search.builds = search.builds[0..limit].to_vec();
-    }
-    debug!("{:?}", search);
-    Ok(search)
 }
 
 fn main() -> Result<(), Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,13 @@
 extern crate hydra_cli;
 
-use hydra_cli::hydra::{Build, Eval, Jobset, JobsetOverview, Reproduce, Search};
+use hydra_cli::hydra::{Eval, Jobset, JobsetOverview, Reproduce, Search};
+use hydra_cli::pretty::{build_pretty_print, evaluation_pretty_print};
 
 extern crate clap;
 extern crate reqwest;
 
 use clap::{App, Arg, SubCommand};
 use reqwest::Error;
-extern crate chrono;
-use chrono::NaiveDateTime;
 #[macro_use]
 extern crate log;
 use serde::de::DeserializeOwned;
@@ -47,36 +46,6 @@ fn test_eval() -> Result<(), std::io::Error> {
     let e: Eval = serde_json::from_str(&contents)?;
     evaluation_pretty_print(&e);
     Ok(())
-}
-
-fn build_pretty_print(b: &Build) {
-    println!("{:14} {}/{}/{}", "Job", b.project, b.jobset, b.job);
-    println!(
-        "{:14} {}",
-        "Finished at",
-        NaiveDateTime::from_timestamp(b.stoptime, 0),
-    );
-    println!("{:14} {}", "Derviation", b.drvpath);
-    println!("{:14}", "Build outputs");
-    for (k, v) in &b.buildoutputs {
-        println!("  {:12} {}", k, v.path);
-    }
-}
-
-fn evaluation_pretty_print(e: &Eval) {
-    for (k, v) in &e.jobsetevalinputs {
-        println!("  {}", k);
-        println!("    {:10} {}", "type", v.input_type);
-        if let Some(t) = &v.value {
-            println!("    {:10} {}", "value", t);
-        }
-        if let Some(t) = &v.uri {
-            println!("    {:10} {}", "uri", t);
-        }
-        if let Some(t) = &v.revision {
-            println!("    {:10} {}", "revision", t);
-        }
-    }
 }
 
 fn query<T: DeserializeOwned>(request_url: String) -> Result<T, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,10 @@ fn main() -> Result<(), Error> {
                 .arg(Arg::with_name("json").short("j").help("JSON output")),
         );
 
+    let mut help_buffer = Vec::new();
+    app.write_help(&mut help_buffer).unwrap();
+    let help_string = String::from_utf8(help_buffer).unwrap();
+
     let matches = app.get_matches();
     let host = matches.value_of("host").unwrap();
     let _ = match matches.subcommand() {
@@ -73,7 +77,10 @@ fn main() -> Result<(), Error> {
             args.is_present("json"),
         ),
 
-        _ => Ok(()),
+        _ => {
+            println!("{}", help_string);
+            Ok(())
+        }
     };
 
     Ok(())

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,0 +1,3 @@
+pub mod project;
+pub mod reproduce;
+pub mod search;

--- a/src/ops/project.rs
+++ b/src/ops/project.rs
@@ -1,0 +1,6 @@
+use reqwest::Error;
+
+pub fn run(host: &str, project: &str) -> Result<(), Error> {
+    println!("host: {}, project: {}", host, project);
+    Ok(())
+}

--- a/src/ops/project.rs
+++ b/src/ops/project.rs
@@ -1,5 +1,5 @@
 use crate::hydra::JobsetOverview;
-use crate::query::jobsetOverview;
+use crate::query::jobset_overview;
 use prettytable::format;
 use reqwest::Error;
 
@@ -9,7 +9,7 @@ pub fn render_response(res: std::vec::Vec<JobsetOverview>) {
     for j in res {
         let mut nrfailed = j.nrfailed.to_string();
         let mut nrscheduled = j.nrscheduled.to_string();
-        let mut name = j.name;
+        let name = j.name;
         if j.nrfailed == 0 {
             nrfailed = "".to_string();
         }
@@ -22,7 +22,7 @@ pub fn render_response(res: std::vec::Vec<JobsetOverview>) {
 }
 
 pub fn run(host: &str, project: &str, to_json: bool) -> Result<(), Error> {
-    let res = jobsetOverview(host, project)?;
+    let res = jobset_overview(host, project)?;
     if to_json {
         println!("{}", serde_json::to_string(&res).unwrap())
     } else {

--- a/src/ops/project.rs
+++ b/src/ops/project.rs
@@ -1,6 +1,32 @@
+use crate::hydra::JobsetOverview;
+use crate::query::jobsetOverview;
+use prettytable::format;
 use reqwest::Error;
 
-pub fn run(host: &str, project: &str) -> Result<(), Error> {
-    println!("host: {}, project: {}", host, project);
+pub fn render_response(res: std::vec::Vec<JobsetOverview>) {
+    let mut table = table!(["Jobset", "Succeeded", "Scheduled", "Failed"]);
+    table.set_format(*format::consts::FORMAT_CLEAN);
+    for j in res {
+        let mut nrfailed = j.nrfailed.to_string();
+        let mut nrscheduled = j.nrscheduled.to_string();
+        let mut name = j.name;
+        if j.nrfailed == 0 {
+            nrfailed = "".to_string();
+        }
+        if j.nrscheduled == 0 {
+            nrscheduled = "".to_string();
+        }
+        table.add_row(row![name, j.nrsucceeded, nrscheduled, nrfailed]);
+    }
+    table.printstd();
+}
+
+pub fn run(host: &str, project: &str, to_json: bool) -> Result<(), Error> {
+    let res = jobsetOverview(host, project)?;
+    if to_json {
+        println!("{}", serde_json::to_string(&res).unwrap())
+    } else {
+        render_response(res)
+    };
     Ok(())
 }

--- a/src/ops/project.rs
+++ b/src/ops/project.rs
@@ -24,7 +24,7 @@ pub fn render_response(res: std::vec::Vec<JobsetOverview>) {
 pub fn run(host: &str, project: &str, to_json: bool) -> Result<(), Error> {
     let res = jobset_overview(host, project)?;
     if to_json {
-        println!("{}", serde_json::to_string(&res).unwrap())
+        println!("{}", serde_json::to_string_pretty(&res).unwrap())
     } else {
         render_response(res)
     };

--- a/src/ops/reproduce.rs
+++ b/src/ops/reproduce.rs
@@ -1,0 +1,6 @@
+use reqwest::Error;
+
+pub fn run(host: &str, query: &str) -> Result<(), Error> {
+    println!("host: {}, query: {}", host, query);
+    Ok(())
+}

--- a/src/ops/reproduce.rs
+++ b/src/ops/reproduce.rs
@@ -28,7 +28,7 @@ pub fn run(host: &str, query: &str, to_json: bool) -> Result<(), Error> {
     };
 
     if to_json {
-        println!("{}", serde_json::to_string(&reproduce).unwrap());
+        println!("{}", serde_json::to_string_pretty(&reproduce).unwrap());
     } else {
         build_pretty_print(&reproduce.build);
         let input = &reproduce.eval.jobsetevalinputs[&reproduce.jobset.nixexprinput];

--- a/src/ops/reproduce.rs
+++ b/src/ops/reproduce.rs
@@ -1,6 +1,47 @@
+use crate::hydra::{Reproduce, Search};
+use crate::pretty::{build_pretty_print, evaluation_pretty_print};
+use crate::query::{eval, jobset, search};
 use reqwest::Error;
 
-pub fn run(host: &str, query: &str) -> Result<(), Error> {
-    println!("host: {}, query: {}", host, query);
+pub fn run(host: &str, query: &str, to_json: bool) -> Result<(), Error> {
+    let mut res: Search = search(host, query, 1)?;
+
+    if res.builds.is_empty() {
+        println!("No builds found. Exiting.");
+        return Ok(());
+    } else if res.builds.len() > 1 {
+        eprintln!(
+            "Warning: the query matches {} builds, considering the first one.",
+            res.builds.len()
+        );
+    }
+    let eval = eval(host.to_string(), res.builds[0].jobsetevals[0])?;
+    let jobset = jobset(
+        host.to_string(),
+        res.builds[0].project.to_string(),
+        res.builds[0].jobset.to_string(),
+    )?;
+    let reproduce = Reproduce {
+        build: res.builds.swap_remove(0),
+        eval,
+        jobset,
+    };
+
+    if to_json {
+        println!("{}", serde_json::to_string(&reproduce).unwrap());
+    } else {
+        build_pretty_print(&reproduce.build);
+        let input = &reproduce.eval.jobsetevalinputs[&reproduce.jobset.nixexprinput];
+        if input.input_type == "git" {
+            println!("{:14} {}", "Repository", input.uri.as_ref().unwrap());
+            println!("{:14} {}", "Revision", input.revision.as_ref().unwrap());
+        }
+        println!("{:14} {}", "Attribute name", reproduce.build.job);
+        println!("{:14} {}", "Nix expr path", reproduce.jobset.nixexprpath);
+
+        println!("Inputs:");
+        evaluation_pretty_print(&reproduce.eval);
+        println!("{:14} {}/build/{}", "Hydra url", host, reproduce.build.id);
+    }
     Ok(())
 }

--- a/src/ops/search.rs
+++ b/src/ops/search.rs
@@ -1,0 +1,12 @@
+use crate::pretty::build_pretty_print;
+use crate::query::search;
+use reqwest::Error;
+
+pub fn run(host: &str, query: &str, limit: usize) -> Result<(), Error> {
+    let search = search(host, query, limit)?;
+    for build in search.builds {
+        build_pretty_print(&build);
+        println!();
+    }
+    Ok(())
+}

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -1,6 +1,39 @@
 use crate::hydra::{Build, Eval};
 use chrono::NaiveDateTime;
 
+#[cfg(test)]
+use crate::hydra::Search;
+#[cfg(test)]
+use std::fs::File;
+#[cfg(test)]
+use std::io::prelude::*;
+
+#[test]
+// This is useful for developping purpose (this is not a test yet).
+fn builds() -> Result<(), std::io::Error> {
+    let mut file = File::open("data/search-build.json")?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    let s: Search = serde_json::from_str(&contents)?;
+
+    for b in s.builds {
+        build_pretty_print(&b);
+        println!();
+    }
+    Ok(())
+}
+
+#[test]
+// This is useful for developping purpose (this is not a test yet).
+fn test_eval() -> Result<(), std::io::Error> {
+    let mut file = File::open("data/eval-1525352.json")?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    let e: Eval = serde_json::from_str(&contents)?;
+    evaluation_pretty_print(&e);
+    Ok(())
+}
+
 pub fn evaluation_pretty_print(e: &Eval) {
     for (k, v) in &e.jobsetevalinputs {
         println!("  {}", k);

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -1,0 +1,32 @@
+use crate::hydra::{Build, Eval};
+use chrono::NaiveDateTime;
+
+pub fn evaluation_pretty_print(e: &Eval) {
+    for (k, v) in &e.jobsetevalinputs {
+        println!("  {}", k);
+        println!("    {:10} {}", "type", v.input_type);
+        if let Some(t) = &v.value {
+            println!("    {:10} {}", "value", t);
+        }
+        if let Some(t) = &v.uri {
+            println!("    {:10} {}", "uri", t);
+        }
+        if let Some(t) = &v.revision {
+            println!("    {:10} {}", "revision", t);
+        }
+    }
+}
+
+pub fn build_pretty_print(b: &Build) {
+    println!("{:14} {}/{}/{}", "Job", b.project, b.jobset, b.job);
+    println!(
+        "{:14} {}",
+        "Finished at",
+        NaiveDateTime::from_timestamp(b.stoptime, 0),
+    );
+    println!("{:14} {}", "Derviation", b.drvpath);
+    println!("{:14}", "Build outputs");
+    for (k, v) in &b.buildoutputs {
+        println!("  {:12} {}", k, v.path);
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -50,6 +50,5 @@ pub fn search(host: &str, queri: &str, limit: usize) -> Result<Search, Error> {
     if search.builds.len() > limit {
         search.builds = search.builds[0..limit].to_vec();
     }
-    debug!("{:?}", search);
     Ok(search)
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -43,7 +43,7 @@ pub fn jobset(host: String, project: String, jobset: String) -> Result<Jobset, E
     Ok(res)
 }
 
-pub fn search(host: String, queri: String, limit: usize) -> Result<Search, Error> {
+pub fn search(host: &str, queri: &str, limit: usize) -> Result<Search, Error> {
     let request_url = format!("{host}/search?query={query}", host = host, query = queri);
     let mut search: Search = query(request_url)?;
     // TODO: implement limit in Hydra API

--- a/src/query.rs
+++ b/src/query.rs
@@ -22,7 +22,7 @@ pub fn eval(host: String, number: i64) -> Result<Eval, Error> {
     Ok(res)
 }
 
-pub fn jobsetOverview(host: String, project: String) -> Result<Vec<JobsetOverview>, Error> {
+pub fn jobsetOverview(host: &str, project: &str) -> Result<Vec<JobsetOverview>, Error> {
     let request_url = format!(
         "{host}/api/jobsets?project={project}",
         host = host,

--- a/src/query.rs
+++ b/src/query.rs
@@ -22,7 +22,7 @@ pub fn eval(host: String, number: i64) -> Result<Eval, Error> {
     Ok(res)
 }
 
-pub fn jobsetOverview(host: &str, project: &str) -> Result<Vec<JobsetOverview>, Error> {
+pub fn jobset_overview(host: &str, project: &str) -> Result<Vec<JobsetOverview>, Error> {
     let request_url = format!(
         "{host}/api/jobsets?project={project}",
         host = host,

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,55 @@
+use crate::hydra::{Eval, Jobset, JobsetOverview, Search};
+use reqwest::Error;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+fn query<T: DeserializeOwned>(request_url: String) -> Result<T, Error> {
+    debug!("Request url: {}", request_url);
+    let client = reqwest::Client::new();
+    let mut res = client
+        .get(&request_url)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .send()?;
+
+    let v: Value = res.json()?;
+    let res = serde_json::from_value(v).unwrap();
+    Ok(res)
+}
+
+pub fn eval(host: String, number: i64) -> Result<Eval, Error> {
+    let request_url = format!("{host}/eval/{number}", host = host, number = number);
+    let res: Eval = query(request_url)?;
+    Ok(res)
+}
+
+pub fn jobsetOverview(host: String, project: String) -> Result<Vec<JobsetOverview>, Error> {
+    let request_url = format!(
+        "{host}/api/jobsets?project={project}",
+        host = host,
+        project = project
+    );
+    let res: Vec<JobsetOverview> = query(request_url)?;
+    Ok(res)
+}
+
+pub fn jobset(host: String, project: String, jobset: String) -> Result<Jobset, Error> {
+    let request_url = format!(
+        "{host}/jobset/{project}/{jobset}",
+        host = host,
+        project = project,
+        jobset = jobset
+    );
+    let res: Jobset = query(request_url)?;
+    Ok(res)
+}
+
+pub fn search(host: String, queri: String, limit: usize) -> Result<Search, Error> {
+    let request_url = format!("{host}/search?query={query}", host = host, query = queri);
+    let mut search: Search = query(request_url)?;
+    // TODO: implement limit in Hydra API
+    if search.builds.len() > limit {
+        search.builds = search.builds[0..limit].to_vec();
+    }
+    debug!("{:?}", search);
+    Ok(search)
+}


### PR DESCRIPTION
This PR is all about splitting up `main.rs` and creating logical units:

- `main.rs` only contains cmdline parsing logic and calls commands
- `lib.rs` makes other modules available to main
- `hydra.rs` contains data types describing json api responses
- `pretty.rs` for pretty printing of some data types
- `query.rs` for calls made to the hydra json api
- `ops/*.rs` for the implementations of the different sub-commands of hydra-cli

Apart from that the PR also..
- Fixes indentation according to `rustfmt`
- introduces some cosmetic changes to please `cargo clippy`
- pretty-prints the json output
