### PR TITLE
Add `project-create`, `jobset-create` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,28 +24,34 @@
         -H <host>        Hydra host URL [env: HYDRA_HOST=]  [default: https://hydra.nixos.org]
     
     SUBCOMMANDS:
-        help         Prints this message or the help of the given subcommand(s)
-        project      Get information of a project
-        reproduce    Retrieve information to reproduce an output path
-        search       Search by output paths
+        create-project    Create a new project
+        help              Prints this message or the help of the given subcommand(s)
+        reproduce         Retrieve information to reproduce an output path
+        search            Search by output paths
+        show-project      Get information of a project
     
     A client to query Hydra through its JSON API.
 
-### Command `hydra-cli project`
+### Command `hydra-cli create-project`
 
-    hydra-cli-project 
-    Get information of a project
+    hydra-cli-create-project 
+    Create a new project
     
     USAGE:
-        hydra-cli project [FLAGS] <PROJECT>
+        hydra-cli create-project <jobset> --config <config> --password <password> --project <project> --user <user>
     
     FLAGS:
         -h, --help       Prints help information
-        -j               JSON output
         -V, --version    Prints version information
     
+    OPTIONS:
+            --config <config>        Project configuration in JSON
+            --password <password>    A user password [env: HYDRA_PW=]
+            --project <project>      The name of the project in which to create the jobset
+            --user <user>            A user name [env: HYDRA_USER=]
+    
     ARGS:
-        <PROJECT>    A project name
+        <jobset>    The name of the jobset to create
 
 ### Command `hydra-cli reproduce`
 
@@ -78,4 +84,20 @@
     ARGS:
         <QUERY>    Piece of an output path (hash, name,...)
         <limit>    How many results to return [default: 10]
+
+### Command `hydra-cli show-project`
+
+    hydra-cli-show-project 
+    Get information of a project
+    
+    USAGE:
+        hydra-cli show-project [FLAGS] <PROJECT>
+    
+    FLAGS:
+        -h, --help       Prints help information
+        -j               JSON output
+        -V, --version    Prints version information
+    
+    ARGS:
+        <PROJECT>    A project name
 

--- a/README.md
+++ b/README.md
@@ -24,21 +24,22 @@
         -H <host>        Hydra host URL [env: HYDRA_HOST=]  [default: https://hydra.nixos.org]
     
     SUBCOMMANDS:
-        create-project    Create a new project
         help              Prints this message or the help of the given subcommand(s)
+        jobset-create     Add jobsets to a project
+        project-create    Create a new project
+        project-show      Get information of a project
         reproduce         Retrieve information to reproduce an output path
         search            Search by output paths
-        show-project      Get information of a project
     
     A client to query Hydra through its JSON API.
 
-### Command `hydra-cli create-project`
+### Command `hydra-cli jobset-create`
 
-    hydra-cli-create-project 
-    Create a new project
+    hydra-cli-jobset-create 
+    Add jobsets to a project
     
     USAGE:
-        hydra-cli create-project <jobset> --config <config> --password <password> --project <project> --user <user>
+        hydra-cli jobset-create <jobset> --config <config> --password <password> --project <project> --user <user>
     
     FLAGS:
         -h, --help       Prints help information
@@ -47,11 +48,46 @@
     OPTIONS:
             --config <config>        Project configuration in JSON
             --password <password>    A user password [env: HYDRA_PW=]
-            --project <project>      The name of the project in which to create the jobset
+            --project <project>      The project to add the jobset to
             --user <user>            A user name [env: HYDRA_USER=]
     
     ARGS:
         <jobset>    The name of the jobset to create
+
+### Command `hydra-cli project-create`
+
+    hydra-cli-project-create 
+    Create a new project
+    
+    USAGE:
+        hydra-cli project-create <project> --password <password> --user <user>
+    
+    FLAGS:
+        -h, --help       Prints help information
+        -V, --version    Prints version information
+    
+    OPTIONS:
+            --password <password>    A user password [env: HYDRA_PW=]
+            --user <user>            A user name [env: HYDRA_USER=]
+    
+    ARGS:
+        <project>    The name of the project in which to create the jobset
+
+### Command `hydra-cli project-show`
+
+    hydra-cli-project-show 
+    Get information of a project
+    
+    USAGE:
+        hydra-cli project-show [FLAGS] <project>
+    
+    FLAGS:
+        -h, --help       Prints help information
+        -j               JSON output
+        -V, --version    Prints version information
+    
+    ARGS:
+        <project>    A project name
 
 ### Command `hydra-cli reproduce`
 
@@ -59,7 +95,7 @@
     Retrieve information to reproduce an output path
     
     USAGE:
-        hydra-cli reproduce [FLAGS] <QUERY>
+        hydra-cli reproduce [FLAGS] <query>
     
     FLAGS:
         -h, --help       Prints help information
@@ -67,7 +103,7 @@
         -V, --version    Prints version information
     
     ARGS:
-        <QUERY>    Piece of an output path (hash, name,...)
+        <query>    Piece of an output path (hash, name,...)
 
 ### Command `hydra-cli search`
 
@@ -75,29 +111,13 @@
     Search by output paths
     
     USAGE:
-        hydra-cli search <QUERY> [limit]
+        hydra-cli search <query> [limit]
     
     FLAGS:
         -h, --help       Prints help information
         -V, --version    Prints version information
     
     ARGS:
-        <QUERY>    Piece of an output path (hash, name,...)
+        <query>    Piece of an output path (hash, name,...)
         <limit>    How many results to return [default: 10]
-
-### Command `hydra-cli show-project`
-
-    hydra-cli-show-project 
-    Get information of a project
-    
-    USAGE:
-        hydra-cli show-project [FLAGS] <PROJECT>
-    
-    FLAGS:
-        -h, --help       Prints help information
-        -j               JSON output
-        -V, --version    Prints version information
-    
-    ARGS:
-        <PROJECT>    A project name
 

--- a/src/hydra.rs
+++ b/src/hydra.rs
@@ -60,3 +60,22 @@ pub struct JobsetOverview {
     pub name: String,
     pub nrfailed: i64,
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct JobsetConfig {
+    pub description: String,
+    pub checkinterval: i64,
+    enabled: bool,
+    visible: bool,
+    keepnr: i64,
+    nixexprinput: String,
+    nixexprpath: String,
+    inputs: HashMap<String, Input>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ProjectConfig {
+    pub displayname: String,
+    pub enabled: bool,
+    pub visible: bool,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,13 @@ fn main() -> Result<(), Error> {
                         .help("Project configuration in JSON"),
                 )
                 .arg(
+                    Arg::with_name("project")
+                        .takes_value(true)
+                        .long("project")
+                        .required(true)
+                        .help("The name of the project in which to create the jobset"),
+                )
+                .arg(
                     Arg::with_name("jobset")
                         .required(true)
                         .help("The name of the jobset to create"),
@@ -112,6 +119,7 @@ fn main() -> Result<(), Error> {
         ("create", Some(args)) => create::run(
             host,
             args.value_of("config").unwrap(),
+            args.value_of("project").unwrap(),
             args.value_of("jobset").unwrap(),
             args.value_of("user").unwrap(),
             args.value_of("password").unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,8 +56,6 @@ fn main() -> Result<(), Error> {
                 .about("Create a new project")
                 .arg(
                     Arg::with_name("project")
-                        .takes_value(true)
-                        .long("project")
                         .required(true)
                         .help("The name of the project in which to create the jobset"),
                 )
@@ -79,7 +77,7 @@ fn main() -> Result<(), Error> {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("project-create")
+            SubCommand::with_name("jobset-create")
                 .about("Add jobsets to a project")
                 .arg(
                     Arg::with_name("config")
@@ -90,9 +88,9 @@ fn main() -> Result<(), Error> {
                 )
                 .arg(
                     Arg::with_name("project")
-                        .takes_value(true)
                         .long("project")
                         .required(true)
+                        .takes_value(true)
                         .help("The project to add the jobset to"),
                 )
                 .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate hydra_cli;
 
 use clap::{App, Arg, SubCommand};
-use hydra_cli::ops::{create, project, reproduce, search};
+use hydra_cli::ops::{jobset_create, project, project_create, reproduce, search};
 use reqwest::Error;
 
 fn main() -> Result<(), Error> {
@@ -42,7 +42,7 @@ fn main() -> Result<(), Error> {
                 .arg(Arg::with_name("json").short("j").help("JSON output")),
         )
         .subcommand(
-            SubCommand::with_name("show-project")
+            SubCommand::with_name("project-show")
                 .about("Get information of a project")
                 .arg(
                     Arg::with_name("PROJECT")
@@ -52,8 +52,35 @@ fn main() -> Result<(), Error> {
                 .arg(Arg::with_name("json").short("j").help("JSON output")),
         )
         .subcommand(
-            SubCommand::with_name("create-project")
+            SubCommand::with_name("project-create")
                 .about("Create a new project")
+                .arg(
+                    Arg::with_name("project")
+                        .takes_value(true)
+                        .long("project")
+                        .required(true)
+                        .help("The name of the project in which to create the jobset"),
+                )
+                .arg(
+                    Arg::with_name("user")
+                        .takes_value(true)
+                        .required(true)
+                        .long("user")
+                        .env("HYDRA_USER")
+                        .help("A user name"),
+                )
+                .arg(
+                    Arg::with_name("password")
+                        .takes_value(true)
+                        .required(true)
+                        .long("password")
+                        .env("HYDRA_PW")
+                        .help("A user password"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("project-create")
+                .about("Add jobsets to a project")
                 .arg(
                     Arg::with_name("config")
                         .takes_value(true)
@@ -66,7 +93,7 @@ fn main() -> Result<(), Error> {
                         .takes_value(true)
                         .long("project")
                         .required(true)
-                        .help("The name of the project in which to create the jobset"),
+                        .help("The project to add the jobset to"),
                 )
                 .arg(
                     Arg::with_name("jobset")
@@ -110,13 +137,20 @@ fn main() -> Result<(), Error> {
             args.is_present("json"),
         ),
 
-        ("show-project", Some(args)) => project::run(
+        ("project-show", Some(args)) => project::run(
             host,
             args.value_of("PROJECT").unwrap(),
             args.is_present("json"),
         ),
 
-        ("create-project", Some(args)) => create::run(
+        ("project-create", Some(args)) => project_create::run(
+            host,
+            args.value_of("project").unwrap(),
+            args.value_of("user").unwrap(),
+            args.value_of("password").unwrap(),
+        ),
+
+        ("jobset-create", Some(args)) => jobset_create::run(
             host,
             args.value_of("config").unwrap(),
             args.value_of("project").unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Error> {
             SubCommand::with_name("search")
                 .about("Search by output paths")
                 .arg(
-                    Arg::with_name("QUERY")
+                    Arg::with_name("query")
                         .required(true)
                         .help("Piece of an output path (hash, name,...)"),
                 )
@@ -35,7 +35,7 @@ fn main() -> Result<(), Error> {
             SubCommand::with_name("reproduce")
                 .about("Retrieve information to reproduce an output path")
                 .arg(
-                    Arg::with_name("QUERY")
+                    Arg::with_name("query")
                         .required(true)
                         .help("Piece of an output path (hash, name,...)"),
                 )
@@ -45,7 +45,7 @@ fn main() -> Result<(), Error> {
             SubCommand::with_name("project-show")
                 .about("Get information of a project")
                 .arg(
-                    Arg::with_name("PROJECT")
+                    Arg::with_name("project")
                         .required(true)
                         .help("A project name"),
                 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate hydra_cli;
 
 use clap::{App, Arg, SubCommand};
-use hydra_cli::ops::{project, reproduce, search};
+use hydra_cli::ops::{create, project, reproduce, search};
 use reqwest::Error;
 
 fn main() -> Result<(), Error> {
@@ -50,6 +50,38 @@ fn main() -> Result<(), Error> {
                         .help("A project name"),
                 )
                 .arg(Arg::with_name("json").short("j").help("JSON output")),
+        )
+        .subcommand(
+            SubCommand::with_name("create")
+                .about("Create a new project")
+                .arg(
+                    Arg::with_name("config")
+                        .takes_value(true)
+                        .long("config")
+                        .required(true)
+                        .help("Project configuration in JSON"),
+                )
+                .arg(
+                    Arg::with_name("jobset")
+                        .required(true)
+                        .help("The name of the jobset to create"),
+                )
+                .arg(
+                    Arg::with_name("user")
+                        .takes_value(true)
+                        .required(true)
+                        .long("user")
+                        .env("HYDRA_USER")
+                        .help("A user name"),
+                )
+                .arg(
+                    Arg::with_name("password")
+                        .takes_value(true)
+                        .required(true)
+                        .long("password")
+                        .env("HYDRA_PW")
+                        .help("A user password"),
+                ),
         );
 
     let mut help_buffer = Vec::new();
@@ -75,6 +107,14 @@ fn main() -> Result<(), Error> {
             host,
             args.value_of("PROJECT").unwrap(),
             args.is_present("json"),
+        ),
+
+        ("create", Some(args)) => create::run(
+            host,
+            args.value_of("config").unwrap(),
+            args.value_of("jobset").unwrap(),
+            args.value_of("user").unwrap(),
+            args.value_of("password").unwrap(),
         ),
 
         _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ use clap::{App, Arg, SubCommand};
 use hydra_cli::ops::{
     jobset_create, project, project_create, reproduce, search, OpError, OpResult,
 };
-use reqwest::Error;
 
 fn main() {
     let app = App::new("hydra-cli")
@@ -127,19 +126,19 @@ fn main() {
     let cmd_res: OpResult = match matches.subcommand() {
         ("search", Some(args)) => search::run(
             host,
-            args.value_of("QUERY").unwrap(),
+            args.value_of("query").unwrap(),
             args.value_of("limit").unwrap().parse().unwrap(),
         ),
 
         ("reproduce", Some(args)) => reproduce::run(
             host,
-            args.value_of("QUERY").unwrap(),
+            args.value_of("query").unwrap(),
             args.is_present("json"),
         ),
 
         ("project-show", Some(args)) => project::run(
             host,
-            args.value_of("PROJECT").unwrap(),
+            args.value_of("project").unwrap(),
             args.is_present("json"),
         ),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Error> {
                 .arg(Arg::with_name("json").short("j").help("JSON output")),
         )
         .subcommand(
-            SubCommand::with_name("project")
+            SubCommand::with_name("show-project")
                 .about("Get information of a project")
                 .arg(
                     Arg::with_name("PROJECT")
@@ -52,7 +52,7 @@ fn main() -> Result<(), Error> {
                 .arg(Arg::with_name("json").short("j").help("JSON output")),
         )
         .subcommand(
-            SubCommand::with_name("create")
+            SubCommand::with_name("create-project")
                 .about("Create a new project")
                 .arg(
                     Arg::with_name("config")
@@ -110,13 +110,13 @@ fn main() -> Result<(), Error> {
             args.is_present("json"),
         ),
 
-        ("project", Some(args)) => project::run(
+        ("show-project", Some(args)) => project::run(
             host,
             args.value_of("PROJECT").unwrap(),
             args.is_present("json"),
         ),
 
-        ("create", Some(args)) => create::run(
+        ("create-project", Some(args)) => create::run(
             host,
             args.value_of("config").unwrap(),
             args.value_of("project").unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,12 +167,16 @@ fn main() {
 
     match cmd_res {
         Ok(_) => std::process::exit(0),
+        Err(OpError::AuthError) => {
+            eprintln!("ERROR: Failed to login. Please check your credentials");
+            std::process::exit(1)
+        }
         Err(OpError::CmdErr) => {
-            eprintln!("hydra-cli called with invalid arguments");
+            eprintln!("ERROR: hydra-cli called with invalid arguments");
             std::process::exit(1)
         }
         Err(OpError::RequestError(m)) => {
-            eprintln!("{}", m);
+            eprintln!("ERROR: {}", m);
             std::process::exit(1)
         }
     }

--- a/src/ops/create.rs
+++ b/src/ops/create.rs
@@ -1,0 +1,16 @@
+use reqwest::Error;
+
+pub fn run(
+    host: &str,
+    config: &str,
+    jobset: &str,
+    user: &str,
+    password: &str,
+) -> Result<(), Error> {
+    debug!(
+        "host: {}, config: {}, jobset: {}, user: {}, pasword: {}",
+        host, config, jobset, user, password
+    );
+
+    Ok(())
+}

--- a/src/ops/create.rs
+++ b/src/ops/create.rs
@@ -1,16 +1,76 @@
+use crate::hydra::{JobsetConfig, ProjectConfig};
+use reqwest::header::REFERER;
 use reqwest::Error;
+use std::collections::HashMap;
+use std::fs::read_to_string;
+
+fn login(client: &reqwest::Client, host: &str, user: &str, password: &str) -> Result<(), Error> {
+    let login_request_url = format!("{host}/login", host = host);
+    let creds: HashMap<&str, &str> = [("username", user), ("password", password)]
+        .iter()
+        .cloned()
+        .collect();
+    client
+        .post(&login_request_url)
+        .header(REFERER, host)
+        .json(&creds)
+        .send()?;
+    Ok(())
+}
+
+fn create_project(client: &reqwest::Client, host: &str, project: &str) -> Result<(), Error> {
+    let create_proj_url = format!("{host}/project/{project}", host = host, project = project);
+    let proj: ProjectConfig = ProjectConfig {
+        displayname: String::from(project),
+        enabled: true,
+        visible: true,
+    };
+    client
+        .put(&create_proj_url)
+        .header(REFERER, host)
+        .json(&proj)
+        .send()?;
+    Ok(())
+}
+
+fn create_jobset(
+    client: &reqwest::Client,
+    host: &str,
+    config: &str,
+    project: &str,
+    jobset: &str,
+) -> Result<(), Error> {
+    let config_str = read_to_string(config).unwrap();
+    let jobset_cfg: JobsetConfig = serde_json::from_str(&config_str).unwrap();
+
+    let jobset_request_url = format!(
+        "{host}/jobset/{project}/{jobset}",
+        host = host,
+        project = project,
+        jobset = jobset
+    );
+    client
+        .put(&jobset_request_url)
+        .header(REFERER, host)
+        .json(&jobset_cfg)
+        .send()?;
+    Ok(())
+}
 
 pub fn run(
     host: &str,
     config: &str,
+    project: &str,
     jobset: &str,
     user: &str,
     password: &str,
 ) -> Result<(), Error> {
-    debug!(
-        "host: {}, config: {}, jobset: {}, user: {}, pasword: {}",
-        host, config, jobset, user, password
-    );
+    println!("Creating jobset '{}' in project '{}'", jobset, project);
+    let client = reqwest::Client::builder().cookie_store(true).build()?;
+
+    login(&client, host, user, password)?;
+    create_project(&client, host, project)?;
+    create_jobset(&client, host, config, project, jobset)?;
 
     Ok(())
 }

--- a/src/ops/jobset_create.rs
+++ b/src/ops/jobset_create.rs
@@ -1,4 +1,4 @@
-use crate::hydra::{JobsetConfig, ProjectConfig};
+use crate::hydra::JobsetConfig;
 use reqwest::header::REFERER;
 use reqwest::Error;
 use std::collections::HashMap;
@@ -19,21 +19,6 @@ fn login(client: &reqwest::Client, host: &str, user: &str, password: &str) -> Re
         .post(&login_request_url)
         .header(REFERER, host)
         .json(&creds)
-        .send()?;
-    Ok(())
-}
-
-fn create_project(client: &reqwest::Client, host: &str, project: &str) -> Result<(), Error> {
-    let create_proj_url = format!("{host}/project/{project}", host = host, project = project);
-    let proj: ProjectConfig = ProjectConfig {
-        displayname: String::from(project),
-        enabled: true,
-        visible: true,
-    };
-    client
-        .put(&create_proj_url)
-        .header(REFERER, host)
-        .json(&proj)
         .send()?;
     Ok(())
 }
@@ -75,7 +60,6 @@ pub fn run(
     let cfg = load_config(config_path);
 
     login(&client, host, user, password)?;
-    create_project(&client, host, project_name)?;
     create_jobset(&client, host, &cfg, project_name, jobset_name)?;
 
     Ok(())

--- a/src/ops/jobset_create.rs
+++ b/src/ops/jobset_create.rs
@@ -1,5 +1,5 @@
 use crate::hydra::JobsetConfig;
-use crate::ops::{ok_msg, OpResult};
+use crate::ops::{ok_msg, OpError, OpResult};
 use reqwest::header::REFERER;
 use reqwest::Response;
 use std::collections::HashMap;
@@ -62,9 +62,12 @@ pub fn run(
     );
     let client = reqwest::Client::builder().cookie_store(true).build()?;
     let cfg = load_config(config_path);
+    let res = login(&client, host, user, password)?;
 
-    login(&client, host, user, password)?;
-    create_jobset(&client, host, &cfg, project_name, jobset_name)?;
-
-    ok_msg("jobset created")
+    if res.status().is_success() {
+        create_jobset(&client, host, &cfg, project_name, jobset_name)?;
+        ok_msg("jobset created")
+    } else {
+        Err(OpError::AuthError)
+    }
 }

--- a/src/ops/jobset_create.rs
+++ b/src/ops/jobset_create.rs
@@ -53,8 +53,8 @@ pub fn run(
     password: &str,
 ) -> Result<(), Error> {
     println!(
-        "Creating jobset '{}' in project '{}'",
-        jobset_name, project_name
+        "Creating jobset '{}' in project '{}' on host '{}' ...",
+        jobset_name, project_name, host
     );
     let client = reqwest::Client::builder().cookie_store(true).build()?;
     let cfg = load_config(config_path);

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -5,6 +5,7 @@ pub mod reproduce;
 pub mod search;
 
 pub enum OpError {
+    AuthError,
     CmdErr,
     RequestError(String),
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,4 +1,5 @@
-pub mod create;
+pub mod jobset_create;
 pub mod project;
+pub mod project_create;
 pub mod reproduce;
 pub mod search;

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -3,3 +3,41 @@ pub mod project;
 pub mod project_create;
 pub mod reproduce;
 pub mod search;
+
+pub enum OpError {
+    CmdErr,
+    RequestError(String),
+}
+
+pub type OpResult = Result<Option<String>, OpError>;
+
+impl From<reqwest::Error> for OpError {
+    fn from(error: reqwest::Error) -> Self {
+        let info = if error.is_client_error() {
+            "client error: "
+        } else if error.is_http() {
+            "http error: "
+        } else if error.is_serialization() {
+            "serialization error: "
+        } else if error.is_server_error() {
+            "server error: "
+        } else if error.is_timeout() {
+            "timeout error: "
+        } else {
+            ""
+        };
+        let msg = format!("{info} {err}", info = info, err = error);
+        OpError::RequestError(msg)
+    }
+}
+
+pub fn ok() -> OpResult {
+    Ok(None)
+}
+
+pub fn ok_msg<T>(message: T) -> OpResult
+where
+    T: Into<String>,
+{
+    Ok(Some(message.into()))
+}

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,3 +1,4 @@
+pub mod create;
 pub mod project;
 pub mod reproduce;
 pub mod search;

--- a/src/ops/project.rs
+++ b/src/ops/project.rs
@@ -1,7 +1,7 @@
 use crate::hydra::JobsetOverview;
+use crate::ops::{ok_msg, OpResult};
 use crate::query::jobset_overview;
 use prettytable::format;
-use reqwest::Error;
 
 pub fn render_response(res: std::vec::Vec<JobsetOverview>) {
     let mut table = table!(["Jobset", "Succeeded", "Scheduled", "Failed"]);
@@ -21,12 +21,12 @@ pub fn render_response(res: std::vec::Vec<JobsetOverview>) {
     table.printstd();
 }
 
-pub fn run(host: &str, project: &str, to_json: bool) -> Result<(), Error> {
+pub fn run(host: &str, project: &str, to_json: bool) -> OpResult {
     let res = jobset_overview(host, project)?;
     if to_json {
         println!("{}", serde_json::to_string_pretty(&res).unwrap())
     } else {
         render_response(res)
     };
-    Ok(())
+    ok_msg("overview created")
 }

--- a/src/ops/project_create.rs
+++ b/src/ops/project_create.rs
@@ -1,5 +1,5 @@
 use crate::hydra::ProjectConfig;
-use crate::ops::{ok_msg, OpResult};
+use crate::ops::{ok_msg, OpError, OpResult};
 use reqwest::header::REFERER;
 use reqwest::Response;
 use std::collections::HashMap;
@@ -44,8 +44,12 @@ pub fn run(host: &str, project_name: &str, user: &str, password: &str) -> OpResu
     println!("Creating project '{}' on host '{}' ...", project_name, host);
 
     let client = reqwest::Client::builder().cookie_store(true).build()?;
-    login(&client, host, user, password)?;
-    create_project(&client, host, project_name)?;
+    let res = login(&client, host, user, password)?;
 
-    ok_msg("project created")
+    if res.status().is_success() {
+        create_project(&client, host, project_name)?;
+        ok_msg("project created")
+    } else {
+        Err(OpError::AuthError)
+    }
 }

--- a/src/ops/project_create.rs
+++ b/src/ops/project_create.rs
@@ -33,6 +33,8 @@ fn login(client: &reqwest::Client, host: &str, user: &str, password: &str) -> Re
 }
 
 pub fn run(host: &str, project_name: &str, user: &str, password: &str) -> Result<(), Error> {
+    println!("Creating project '{}' on host '{}' ...", project_name, host);
+
     let client = reqwest::Client::builder().cookie_store(true).build()?;
     login(&client, host, user, password)?;
     create_project(&client, host, project_name)?;

--- a/src/ops/project_create.rs
+++ b/src/ops/project_create.rs
@@ -1,9 +1,14 @@
 use crate::hydra::ProjectConfig;
+use crate::ops::{ok_msg, OpResult};
 use reqwest::header::REFERER;
-use reqwest::Error;
+use reqwest::Response;
 use std::collections::HashMap;
 
-fn create_project(client: &reqwest::Client, host: &str, project: &str) -> Result<(), Error> {
+fn create_project(
+    client: &reqwest::Client,
+    host: &str,
+    project: &str,
+) -> reqwest::Result<Response> {
     let create_proj_url = format!("{host}/project/{project}", host = host, project = project);
     let proj: ProjectConfig = ProjectConfig {
         displayname: String::from(project),
@@ -14,11 +19,15 @@ fn create_project(client: &reqwest::Client, host: &str, project: &str) -> Result
         .put(&create_proj_url)
         .header(REFERER, host)
         .json(&proj)
-        .send()?;
-    Ok(())
+        .send()
 }
 
-fn login(client: &reqwest::Client, host: &str, user: &str, password: &str) -> Result<(), Error> {
+fn login(
+    client: &reqwest::Client,
+    host: &str,
+    user: &str,
+    password: &str,
+) -> reqwest::Result<Response> {
     let login_request_url = format!("{host}/login", host = host);
     let creds: HashMap<&str, &str> = [("username", user), ("password", password)]
         .iter()
@@ -28,16 +37,15 @@ fn login(client: &reqwest::Client, host: &str, user: &str, password: &str) -> Re
         .post(&login_request_url)
         .header(REFERER, host)
         .json(&creds)
-        .send()?;
-    Ok(())
+        .send()
 }
 
-pub fn run(host: &str, project_name: &str, user: &str, password: &str) -> Result<(), Error> {
+pub fn run(host: &str, project_name: &str, user: &str, password: &str) -> OpResult {
     println!("Creating project '{}' on host '{}' ...", project_name, host);
 
     let client = reqwest::Client::builder().cookie_store(true).build()?;
     login(&client, host, user, password)?;
     create_project(&client, host, project_name)?;
 
-    Ok(())
+    ok_msg("project created")
 }

--- a/src/ops/project_create.rs
+++ b/src/ops/project_create.rs
@@ -1,0 +1,41 @@
+use crate::hydra::ProjectConfig;
+use reqwest::header::REFERER;
+use reqwest::Error;
+use std::collections::HashMap;
+
+fn create_project(client: &reqwest::Client, host: &str, project: &str) -> Result<(), Error> {
+    let create_proj_url = format!("{host}/project/{project}", host = host, project = project);
+    let proj: ProjectConfig = ProjectConfig {
+        displayname: String::from(project),
+        enabled: true,
+        visible: true,
+    };
+    client
+        .put(&create_proj_url)
+        .header(REFERER, host)
+        .json(&proj)
+        .send()?;
+    Ok(())
+}
+
+fn login(client: &reqwest::Client, host: &str, user: &str, password: &str) -> Result<(), Error> {
+    let login_request_url = format!("{host}/login", host = host);
+    let creds: HashMap<&str, &str> = [("username", user), ("password", password)]
+        .iter()
+        .cloned()
+        .collect();
+    client
+        .post(&login_request_url)
+        .header(REFERER, host)
+        .json(&creds)
+        .send()?;
+    Ok(())
+}
+
+pub fn run(host: &str, project_name: &str, user: &str, password: &str) -> Result<(), Error> {
+    let client = reqwest::Client::builder().cookie_store(true).build()?;
+    login(&client, host, user, password)?;
+    create_project(&client, host, project_name)?;
+
+    Ok(())
+}

--- a/src/ops/reproduce.rs
+++ b/src/ops/reproduce.rs
@@ -1,14 +1,14 @@
 use crate::hydra::{Reproduce, Search};
+use crate::ops::{ok_msg, OpResult};
 use crate::pretty::{build_pretty_print, evaluation_pretty_print};
 use crate::query::{eval, jobset, search};
-use reqwest::Error;
 
-pub fn run(host: &str, query: &str, to_json: bool) -> Result<(), Error> {
+pub fn run(host: &str, query: &str, to_json: bool) -> OpResult {
     let mut res: Search = search(host, query, 1)?;
 
     if res.builds.is_empty() {
         println!("No builds found. Exiting.");
-        return Ok(());
+        return ok_msg("no builds found");
     } else if res.builds.len() > 1 {
         eprintln!(
             "Warning: the query matches {} builds, considering the first one.",
@@ -43,5 +43,5 @@ pub fn run(host: &str, query: &str, to_json: bool) -> Result<(), Error> {
         evaluation_pretty_print(&reproduce.eval);
         println!("{:14} {}/build/{}", "Hydra url", host, reproduce.build.id);
     }
-    Ok(())
+    ok_msg("reproduce info created")
 }

--- a/src/ops/search.rs
+++ b/src/ops/search.rs
@@ -1,12 +1,12 @@
+use crate::ops::{ok_msg, OpResult};
 use crate::pretty::build_pretty_print;
 use crate::query::search;
-use reqwest::Error;
 
-pub fn run(host: &str, query: &str, limit: usize) -> Result<(), Error> {
+pub fn run(host: &str, query: &str, limit: usize) -> OpResult {
     let search = search(host, query, limit)?;
     for build in search.builds {
         build_pretty_print(&build);
         println!();
     }
-    Ok(())
+    ok_msg("search")
 }


### PR DESCRIPTION
* `project-create` command
```
hydra-cli-project-create
Create a new project

USAGE:
    hydra-cli project-create <project> --password <password> --user <user>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --password <password>    A user password [env: HYDRA_PW=]
        --user <user>            A user name [env: HYDRA_USER=]

ARGS:
    <project>    The name of the project in which to create the jobset
```

* `jobset-crate` command
```
hydra-cli-jobset-create 
Add jobsets to a project

USAGE:
    hydra-cli jobset-create <jobset> --config <config> --password <password> --project <project> --user <user>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --config <config>        Project configuration in JSON
        --password <password>    A user password [env: HYDRA_PW=]
        --project <project>      The project to add the jobset to
        --user <user>            A user name [env: HYDRA_USER=]

ARGS:
    <jobset>    The name of the jobset to create
```

----

The changes introduced through this PR definitely warrant some follow-up that improves on code-reuse and *error handling* plus some logging/tracing