### PR TITLE
wip: Remove errormsg from the `jobsetOverview` struct

### DIFF
--- a/src/hydra/types.rs
+++ b/src/hydra/types.rs
@@ -91,7 +91,6 @@ pub struct JobsetOverview {
     pub nrfailed: i64,
     pub starttime: Option<PosixTimestamp>,
     pub lastcheckedtime: PosixTimestamp,
-    pub errormsg: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Because `errormsg` can be arbitrarily long, it is no longer part of the
default jobset api response.