### PR TITLE
jobset-create: change command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,20 +141,20 @@ hydra-cli-jobset-create
 Add jobsets to a project
 
 USAGE:
-    hydra-cli jobset-create <jobset> --config <config> --password <password> --project <project> --user <user>
+    hydra-cli jobset-create <project> <jobset> <config> --password <password> --user <user>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
 OPTIONS:
-        --config <config>        Project configuration in JSON
         --password <password>    A user password [env: HYDRA_PW=]
-        --project <project>      The project to add the jobset to
         --user <user>            A user name [env: HYDRA_USER=]
 
 ARGS:
-    <jobset>    The name of the jobset to create
+    <project>    The project to add the jobset to
+    <jobset>     The name of the jobset to create
+    <config>     Project configuration in JSON
 ```
 #### jobset-wait
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,23 +88,19 @@ fn main() {
             SubCommand::with_name("jobset-create")
                 .about("Add jobsets to a project")
                 .arg(
-                    Arg::with_name("config")
-                        .takes_value(true)
-                        .long("config")
-                        .required(true)
-                        .help("Project configuration in JSON"),
-                )
-                .arg(
                     Arg::with_name("project")
-                        .long("project")
                         .required(true)
-                        .takes_value(true)
                         .help("The project to add the jobset to"),
                 )
                 .arg(
                     Arg::with_name("jobset")
                         .required(true)
                         .help("The name of the jobset to create"),
+                )
+                .arg(
+                    Arg::with_name("config")
+                        .required(true)
+                        .help("Project configuration in JSON"),
                 )
                 .arg(
                     Arg::with_name("user")

--- a/tests/vm.nix
+++ b/tests/vm.nix
@@ -101,10 +101,10 @@ makeTest {
     $machine->succeed("hydra-cli -H http://localhost:3000 project-create test --password admin --user admin");
     $machine->succeed("hydra-cli -H http://localhost:3000 project-list | grep -q test");
 
-    $machine->succeed("hydra-cli -H http://localhost:3000 jobset-create success --password admin --user admin --project test --config ${jobsetSuccess}");
+    $machine->succeed("hydra-cli -H http://localhost:3000 jobset-create test success ${jobsetSuccess} --password admin --user admin ");
     $machine->succeed("hydra-cli -H http://localhost:3000 jobset-wait test success");
 
-    $machine->succeed("hydra-cli -H http://localhost:3000 jobset-create success --password admin --user admin --project test --config ${jobsetFail}");
+    $machine->succeed("hydra-cli -H http://localhost:3000 jobset-create test success ${jobsetFail} --password admin --user admin");
     $machine->fail("hydra-cli -H http://localhost:3000 jobset-wait test fail");
   '';
 }


### PR DESCRIPTION
This PR changes the `jobset-create` syntax to:

```
hydra-cli jobset-create <project> <jobset> <config> --password <password> --user <user>
```

This PR boils down to:
- Adjusting args in clap
- Updating the `jobset-create` syntax in the tests after rebasing on top of master