### PR TITLE
More nullable attributes in the `jobsetOverview` structure

### DIFF
--- a/src/hydra/types.rs
+++ b/src/hydra/types.rs
@@ -90,8 +90,8 @@ pub struct JobsetOverview {
     pub name: String,
     pub nrfailed: i64,
     pub starttime: Option<PosixTimestamp>,
-    pub lastcheckedtime: PosixTimestamp,
-    pub errormsg: String,
+    pub lastcheckedtime: Option<PosixTimestamp>,
+    pub errormsg: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/ops/jobset_wait.rs
+++ b/src/ops/jobset_wait.rs
@@ -17,11 +17,14 @@ fn evaluation_started_since(jobset: &JobsetOverview) -> Option<Duration> {
 }
 
 fn is_evaluation_finished_after(jobset: &JobsetOverview, start: SystemTime) -> bool {
-    (UNIX_EPOCH + Duration::from_secs(jobset.lastcheckedtime)) > start
+    match jobset.lastcheckedtime {
+        None => false,
+        Some(t) => (UNIX_EPOCH + Duration::from_secs(t)) > start,
+    }
 }
 
 fn is_jobset_built(jobset: &JobsetOverview) -> Result<bool, OpError> {
-    if jobset.errormsg != "" {
+    if jobset.errormsg.clone().map_or(false, |m| m != "") {
         println!();
         Err(OpError::Error(format!(
             "evaluation of jobset {} failed",


### PR DESCRIPTION
At jobset initialisation, Hydra sets several attributes to null, such
as `lastcheckedtime` and `errormsg`.

Fixes #25