### PR TITLE
Add no-check-certificate flag to disable TLS cert checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ lewo
 CLI Hydra client
 
 USAGE:
-    hydra-cli [OPTIONS] [SUBCOMMAND]
+    hydra-cli [FLAGS] [OPTIONS] [SUBCOMMAND]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help                    Prints help information
+        --no-check-certificate    Disable TLS certificate check for the Hydra host
+    -V, --version                 Prints version information
 
 OPTIONS:
     -H <host>        Hydra host URL [env: HYDRA_HOST=]  [default: https://hydra.nixos.org]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,11 @@ fn main() {
                 .env("HYDRA_HOST")
                 .help("Hydra host URL"),
         )
+        .arg(
+            Arg::with_name("no-check-certificate")
+                .long("no-check-certificate")
+                .help("Disable TLS certificate check for the Hydra host"),
+        )
         .subcommand(
             SubCommand::with_name("search")
                 .about("Search by output paths")
@@ -140,8 +145,10 @@ fn main() {
 
     let matches = app.get_matches();
     let host = matches.value_of("host").unwrap();
+    let no_check_certs = matches.is_present("no-check-certificate");
     let c = reqwest::Client::builder()
         .cookie_store(true)
+        .danger_accept_invalid_certs(no_check_certs)
         .build()
         .unwrap();
     let client = ReqwestHydraClient::new(c, String::from(host));


### PR DESCRIPTION
`hydra-cli` seems like a great tool! Thanks for making it. :smile: 
Unfortunately the `hydra` host we use at work is on an internal network using self-signed TLS certificates.

Would this flag I've added be of interest to other people?
Would you prefer if this new option was `hidden` by default (I know clap makes it possible to hide options from the help menu)?