### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydra-cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Antoine Eiche <lewo@abesis.fr>", "Tobias Pflug <tobias.pflug@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Bump `hydra-cli` version to `0.2.0` for the first release.