### PR TITLE
Add OneShot option to jobset config

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,28 @@ ARGS:
     <project>    The project to add the jobset to
     <jobset>     The name of the jobset to create
     <config>     Project configuration JSON filepath
+
+Here is an example JSON config:
+
+    {
+      "enabled": 1,
+      "visible": true,
+      "description": "hydra-cli master jobset",
+      "nixexprinput": "src",
+      "nixexprpath": "default.nix",
+      "checkinterval": 60,
+      "schedulingshares": 100,
+      "enableemail": false,
+      "emailoverride": "",
+      "keepnr": 3,
+      "inputs": {
+        "src": {
+          "type": "git",
+          "value": "https://github.com/nlewo/hydra-cli.git master",
+          "emailresponsible": false
+        }
+      }
+    }
 ```
 #### jobset-eval
 

--- a/README.md
+++ b/README.md
@@ -164,25 +164,23 @@ ARGS:
 
 Here is an example JSON config:
 
-    {
-      "enabled": 1,
-      "visible": true,
-      "description": "hydra-cli master jobset",
-      "nixexprinput": "src",
-      "nixexprpath": "default.nix",
-      "checkinterval": 60,
-      "schedulingshares": 100,
-      "enableemail": false,
-      "emailoverride": "",
-      "keepnr": 3,
-      "inputs": {
-        "src": {
-          "type": "git",
-          "value": "https://github.com/nlewo/hydra-cli.git master",
-          "emailresponsible": false
-        }
-      }
+{
+  "description": "hydra-cli master jobset",
+  "checkinterval": 60,
+  "enabled": 1,
+  "visible": true,
+  "keepnr": 3,
+  "nixexprinput": "src",
+  "nixexprpath": "default.nix",
+  "inputs": {
+    "src": {
+      "value": "https://github.com/nlewo/hydra-cli.git master",
+      "type": "git",
+      "revision": null,
+      "uri": null
     }
+  }
+}
 ```
 #### jobset-eval
 

--- a/src/hydra/example.rs
+++ b/src/hydra/example.rs
@@ -1,0 +1,27 @@
+//! Examples intended for the CLI help sections
+
+pub use crate::hydra::types::{Input, JobsetConfig, JobsetEnabled};
+use std::collections::HashMap;
+
+pub fn jobset_config() -> JobsetConfig {
+    JobsetConfig {
+        description: "hydra-cli master jobset".to_string(),
+        checkinterval: 60,
+        enabled: JobsetEnabled::Enabled,
+        visible: true,
+        keepnr: 3,
+        nixexprinput: "src".to_string(),
+        nixexprpath: "default.nix".to_string(),
+        inputs: {
+            let mut map = HashMap::<String, Input>::new();
+            let input = Input {
+                value: Some("https://github.com/nlewo/hydra-cli.git master".to_string()),
+                input_type: "git".to_string(),
+                revision: None,
+                uri: None,
+            };
+            map.insert("src".to_string(), input);
+            map
+        },
+    }
+}

--- a/src/hydra/mod.rs
+++ b/src/hydra/mod.rs
@@ -1,3 +1,4 @@
 pub mod client;
+pub mod example;
 pub mod reqwest_client;
 mod types;

--- a/src/hydra/reqwest_client.rs
+++ b/src/hydra/reqwest_client.rs
@@ -10,6 +10,9 @@ use std::collections::HashMap;
 #[cfg(test)]
 use mockito;
 
+#[cfg(test)]
+use crate::hydra::types::JobsetEnabled;
+
 impl From<reqwest::Error> for ClientError {
     fn from(e: reqwest::Error) -> Self {
         let msg = format!("{}", e);
@@ -268,7 +271,7 @@ mod tests {
         let jobset = JobsetConfig {
             description: "desc".to_string(),
             checkinterval: 100,
-            enabled: true,
+            enabled: JobsetEnabled::Enabled,
             visible: true,
             nixexprinput: "input".to_string(),
             nixexprpath: "path".to_string(),
@@ -289,7 +292,7 @@ mod tests {
         let jobset = JobsetConfig {
             description: "desc".to_string(),
             checkinterval: 100,
-            enabled: true,
+            enabled: JobsetEnabled::Enabled,
             visible: true,
             nixexprinput: "input".to_string(),
             nixexprpath: "path".to_string(),

--- a/src/hydra/types.rs
+++ b/src/hydra/types.rs
@@ -94,11 +94,18 @@ pub struct JobsetOverview {
     pub haserrormsg: bool,
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub enum JobsetEnabled {
+    Disabled = 0,
+    Enabled = 1,
+    OneShot = 2,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct JobsetConfig {
     pub description: String,
     pub checkinterval: i64,
-    pub enabled: bool,
+    pub enabled: JobsetEnabled,
     pub visible: bool,
     pub keepnr: i64,
     pub nixexprinput: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,29 @@ fn main() {
                         .long("password")
                         .env("HYDRA_PASSWORD")
                         .help("A user password"),
+                )
+                .after_help(
+                    "Here is an example JSON config:
+
+    {
+      \"enabled\": 1,
+      \"visible\": true,
+      \"description\": \"hydra-cli master jobset\",
+      \"nixexprinput\": \"src\",
+      \"nixexprpath\": \"default.nix\",
+      \"checkinterval\": 60,
+      \"schedulingshares\": 100,
+      \"enableemail\": false,
+      \"emailoverride\": \"\",
+      \"keepnr\": 3,
+      \"inputs\": {
+        \"src\": {
+          \"type\": \"git\",
+          \"value\": \"https://github.com/nlewo/hydra-cli.git master\",
+          \"emailresponsible\": false
+        }
+      }
+    }",
                 ),
         )
         .subcommand(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 extern crate hydra_cli;
 
 use clap::{App, Arg, SubCommand};
+use hydra_cli::hydra::example::jobset_config;
 use hydra_cli::hydra::reqwest_client::Client as ReqwestHydraClient;
 use hydra_cli::ops::{
     jobset_create, jobset_eval, jobset_wait, project, project_create, project_list, reproduce,
@@ -8,6 +9,10 @@ use hydra_cli::ops::{
 };
 
 fn main() {
+    let config_after_help = &format!(
+        "Here is an example JSON config:\n\n{}",
+        serde_json::to_string_pretty(&jobset_config()).unwrap()
+    )[..];
     let app = App::new("hydra-cli")
         .version("0.2.0")
         .about("CLI Hydra client")
@@ -124,29 +129,7 @@ fn main() {
                         .env("HYDRA_PASSWORD")
                         .help("A user password"),
                 )
-                .after_help(
-                    "Here is an example JSON config:
-
-    {
-      \"enabled\": 1,
-      \"visible\": true,
-      \"description\": \"hydra-cli master jobset\",
-      \"nixexprinput\": \"src\",
-      \"nixexprpath\": \"default.nix\",
-      \"checkinterval\": 60,
-      \"schedulingshares\": 100,
-      \"enableemail\": false,
-      \"emailoverride\": \"\",
-      \"keepnr\": 3,
-      \"inputs\": {
-        \"src\": {
-          \"type\": \"git\",
-          \"value\": \"https://github.com/nlewo/hydra-cli.git master\",
-          \"emailresponsible\": false
-        }
-      }
-    }",
-                ),
+                .after_help(config_after_help),
         )
         .subcommand(
             SubCommand::with_name("jobset-eval")

--- a/tests/vm.nix
+++ b/tests/vm.nix
@@ -44,7 +44,7 @@ let
     text = builtins.toJSON {
       inherit description;
       checkinterval = 60;
-      enabled = true;
+      enabled = 1;
       visible = true;
       keepnr = 1;
       nixexprinput = "expr";


### PR DESCRIPTION
This PR also shows an example JSON config as this is not an obvious setup. The only documentation I could find was https://nixos.org/hydra/manual/#sec-declarative-projects which seems outdated.

Is there anyway to generate that example config from something that is typed? That might be more future proof, what do you think?