### PR TITLE
Add a timeout option to the jobset-wait subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,11 +212,14 @@ hydra-cli-jobset-wait
 Wait for jobset completion
 
 USAGE:
-    hydra-cli jobset-wait <project> <jobset>
+    hydra-cli jobset-wait [OPTIONS] <project> <jobset>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
+
+OPTIONS:
+        --timeout <timeout>    Maximum time to wait for (in seconds)
 
 ARGS:
     <project>    The project of the jobset to wait for

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 extern crate hydra_cli;
 
 use clap::{App, Arg, SubCommand};
+use std::str::FromStr;
+use std::time::Duration;
+
 use hydra_cli::hydra::example::jobset_config;
 use hydra_cli::hydra::reqwest_client::Client as ReqwestHydraClient;
 use hydra_cli::ops::{
@@ -157,6 +160,12 @@ fn main() {
                     Arg::with_name("jobset")
                         .required(true)
                         .help("The name of the jobset to wait for"),
+                )
+                .arg(
+                    Arg::with_name("timeout")
+                        .long("timeout")
+                        .takes_value(true)
+                        .help("Maximum time to wait for (in seconds)"),
                 ),
         );
 
@@ -222,6 +231,8 @@ fn main() {
             &client,
             args.value_of("project").unwrap(),
             args.value_of("jobset").unwrap(),
+            args.value_of("timeout")
+                .map(|t| Duration::from_secs(u64::from_str(t).unwrap())),
         ),
 
         _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,6 +255,10 @@ fn main() {
             eprintln!("ERROR: {}", m);
             std::process::exit(1)
         }
+        Err(OpError::TimeoutError) => {
+            eprintln!("ERROR: Timeout");
+            std::process::exit(124)
+        }
         Err(OpError::Error(m)) => {
             eprintln!("ERROR: {}", m);
             std::process::exit(1)

--- a/src/ops/jobset_wait.rs
+++ b/src/ops/jobset_wait.rs
@@ -97,7 +97,7 @@ pub fn run(
     loop {
         match timeout {
             Some(t) if SystemTime::now().duration_since(timeout_start).unwrap() > t => {
-                return Err(OpError::Error("jobset-wait timeout error".to_string()))
+                return Err(OpError::TimeoutError)
             }
             _ => {}
         }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -10,6 +10,7 @@ pub mod search;
 pub enum OpError {
     AuthError,
     CmdErr,
+    TimeoutError,
     Error(String),
     RequestError(String),
 }


### PR DESCRIPTION
This PR implements a timeout option for the `jobset-wait` subcommand.

Closes #36