### PR TITLE
jobset-wait: wait for jobset creation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ fn main() {
                     Arg::with_name("timeout")
                         .long("timeout")
                         .takes_value(true)
-                        .help("Maximum time to wait for (in seconds)"),
+                        .help("Maximum time to wait for (in seconds and infinite by default)"),
                 ),
         );
 


### PR DESCRIPTION
Hydra could take some time to create the jobset. In this case, we have
to retry until the jobset exists.