### PR TITLE
Fix parsing issue in project-list

### DIFF
--- a/src/hydra/types.rs
+++ b/src/hydra/types.rs
@@ -36,10 +36,10 @@ impl de::Visitor<'_> for BoolFromInt {
     type Value = bool;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("Expecting a boolean either encoded as a u8 or as a bool")
+        formatter.write_str("Expecting a boolean either encoded as an unsigned int or as a bool")
     }
 
-    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
     where
         E: de::Error,
     {

--- a/src/ops/jobset_wait.rs
+++ b/src/ops/jobset_wait.rs
@@ -95,7 +95,7 @@ pub fn run(
         WaitingForNewEval,
         Evaluating,
         Building,
-    };
+    }
     let sleep = Duration::from_secs(2);
     let mut state = State::WaitingForJobset;
     let mut start = SystemTime::now();


### PR DESCRIPTION
Newer versions of `hydra` now return json with `false`/`true` where they used to have `0`/`1`