### PR TITLE
Handle new hydra login API issue

### DIFF
--- a/src/hydra/reqwest_client.rs
+++ b/src/hydra/reqwest_client.rs
@@ -151,6 +151,10 @@ impl HydraClient for Client {
             Ok(r) => {
                 if r.status().is_success() {
                     Ok(())
+                } else if r.status() == 500 {
+                    // New hydra gives a 302 redirect to a page that ends up with a 500
+                    // Ideally we would not follow the redirect
+                    Ok(()) // ignore redirect error
                 } else {
                     Err(ClientError::Error(format!("{}", r.status())))
                 }


### PR DESCRIPTION
Login started failing with the latest version of `hydra`. For some reason `hydra` now returns a `302` that redirects to a `500` when login in. I guess that's not an issue for the web frontend that probably dismisses the redirect, unfortunately `reqwest` follows it.